### PR TITLE
Feature trim start

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -5,6 +5,7 @@ from bpy.props import (
     EnumProperty,
     StringProperty,
     IntProperty,
+    IntVectorProperty,
 )
 
 from . import add_pre_suffix
@@ -163,7 +164,7 @@ def register():
     id_store.renaming_base_numerate = IntProperty(name="Step Size", default=1)
     id_store.renaming_start_number = IntProperty(name="Step Size", default=1)
     id_store.renaming_digits_numerate = IntProperty(name="Number Length", default=3)
-    id_store.renaming_cut_size = IntProperty(name="Trim Size", default=3)
+    id_store.renaming_trim_indices = IntVectorProperty(name="Trim Size", default=(0, 0), min=0, soft_min=0, size=2)
 
     from bpy.utils import register_class
 
@@ -190,6 +191,6 @@ def unregister():
     del IDStore.renaming_only_selection
     del IDStore.renaming_base_numerate
     del IDStore.renaming_digits_numerate
-    del IDStore.renaming_cut_size
+    del IDStore.renaming_trim_indices
 
     bpy.app.handlers.depsgraph_update_post.remove(PostChange)

--- a/operators/renaming_utilities.py
+++ b/operators/renaming_utilities.py
@@ -5,9 +5,7 @@ from .. import __package__ as base_package
 
 
 def trim_string(string, size):
-    list1 = string
-    list2 = list1[:-size]
-    return ''.join(list2)
+    return string[size[0]:max(0, len(string)-size[1])]
 
 
 def get_renaming_list(context):

--- a/operators/trim_string.py
+++ b/operators/trim_string.py
@@ -2,8 +2,7 @@ import bpy
 
 from .renaming_operators import switch_to_edit_mode
 from ..operators.renaming_utilities import get_renaming_list, trim_string, call_renaming_popup, call_error_popup
-
-
+    
 class VIEW3D_OT_trim_string(bpy.types.Operator):
     bl_idname = "renaming.trim_string"
     bl_label = "Trim Start and End of String"
@@ -25,15 +24,16 @@ class VIEW3D_OT_trim_string(bpy.types.Operator):
         if len(renaming_list) > 0:
             for entity in renaming_list:
                 if entity is not None:
-                    oldName = entity.name
+                    old_name = entity.name
                     new_name = trim_string(entity.name, wm.renaming_trim_indices)
                     entity.name = new_name
-                    wm.renaming_trim_indices=(0,0)
-                    msg.add_message(oldName, entity.name)
+                    msg.add_message(old_name, entity.name)
 
+        wm.renaming_trim_indices = (0, 0)
+        
         call_renaming_popup(context)
 
         if switch_edit_mode:
             switch_to_edit_mode(context)
-
+            
         return {'FINISHED'}

--- a/operators/trim_string.py
+++ b/operators/trim_string.py
@@ -28,8 +28,6 @@ class VIEW3D_OT_trim_string(bpy.types.Operator):
                     new_name = trim_string(entity.name, wm.renaming_trim_indices)
                     entity.name = new_name
                     msg.add_message(old_name, entity.name)
-
-        wm.renaming_trim_indices = (0, 0)
         
         call_renaming_popup(context)
 

--- a/operators/trim_string.py
+++ b/operators/trim_string.py
@@ -5,9 +5,9 @@ from ..operators.renaming_utilities import get_renaming_list, trim_string, call_
 
 
 class VIEW3D_OT_trim_string(bpy.types.Operator):
-    bl_idname = "renaming.cut_string"
-    bl_label = "Trim End of String"
-    bl_description = "Deletes the in the trim size specified amount of characters at the end of object names"
+    bl_idname = "renaming.trim_string"
+    bl_label = "Trim Start and End of String"
+    bl_description = "Deletes the in the trim size specified amount of characters at the start or the end of object names"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
@@ -26,8 +26,9 @@ class VIEW3D_OT_trim_string(bpy.types.Operator):
             for entity in renaming_list:
                 if entity is not None:
                     oldName = entity.name
-                    new_name = trim_string(entity.name, wm.renaming_cut_size)
+                    new_name = trim_string(entity.name, wm.renaming_trim_indices)
                     entity.name = new_name
+                    wm.renaming_trim_indices=(0,0)
                     msg.add_message(oldName, entity.name)
 
         call_renaming_popup(context)

--- a/operators/trim_string.py
+++ b/operators/trim_string.py
@@ -5,7 +5,7 @@ from ..operators.renaming_utilities import get_renaming_list, trim_string, call_
     
 class VIEW3D_OT_trim_string(bpy.types.Operator):
     bl_idname = "renaming.trim_string"
-    bl_label = "Trim Start and End of String"
+    bl_label = "Trim String"
     bl_description = "Deletes the in the trim size specified amount of characters at the start or the end of object names"
     bl_options = {'REGISTER', 'UNDO'}
 

--- a/ui/renaming_panels.py
+++ b/ui/renaming_panels.py
@@ -126,14 +126,19 @@ def draw_renaming_panel(layout, context):
 
     ###############################################
     layout.separator()
-    layout.label(text="Other")
+    layout.label(text="Trim")
 
-    row = layout.row(align=True)
-    row.operator("renaming.numerate", icon="LINENUMBERS_ON")
-
+    # TRIM
     row = layout.row(align=True)
     row.operator("renaming.cut_string", icon="X")
     row.prop(scene, "renaming_cut_size", text="")
+
+    ###############################################
+    layout.separator()
+    layout.label(text="Other")
+
+    row = layout.row(align=True)
+    row.operator("renaming.numerate", icon="LINENUMBERS_ON")    
 
     if str(scene.renaming_object_types) in ('DATA', 'OBJECT', 'ADDOBJECTS'):
         layout.label(text="Data Name")

--- a/ui/renaming_panels.py
+++ b/ui/renaming_panels.py
@@ -143,6 +143,7 @@ def draw_renaming_panel(layout, context):
     row.operator("renaming.numerate", icon="LINENUMBERS_ON")    
 
     if str(scene.renaming_object_types) in ('DATA', 'OBJECT', 'ADDOBJECTS'):
+        layout.separator()
         layout.label(text="Data Name")
 
         col = layout.column(align=True)

--- a/ui/renaming_panels.py
+++ b/ui/renaming_panels.py
@@ -129,9 +129,11 @@ def draw_renaming_panel(layout, context):
     layout.label(text="Trim")
 
     # TRIM
+    col = layout.column(align=True)
+    col.prop(scene, "renaming_trim_indices",index=0,text="First")
+    col.prop(scene, "renaming_trim_indices",index=1,text="Last")
     row = layout.row(align=True)
-    row.operator("renaming.cut_string", icon="X")
-    row.prop(scene, "renaming_cut_size", text="")
+    row.operator("renaming.trim_string", icon="X")
 
     ###############################################
     layout.separator()


### PR DESCRIPTION
Fixes #196

Hi,
I expanded the string trim function, so that its possible to trim characters from the start of the string as well as from the end.
On the UI side, i moved the trim function into its own section. 


![demonstration](https://github.com/user-attachments/assets/5b20a7da-dee4-49a6-9fbf-fcdce047cd13)
