### PR TITLE
Fix: selection_order is keyframed when pressing I

### DIFF
--- a/operators/renaming_utilities.py
+++ b/operators/renaming_utilities.py
@@ -283,6 +283,16 @@ def update_selection_order():
             clear_order_flag(o)
         else:
             o["selection_order"] = idx
+
+            # Hackish way to prevent unwanted keyframing of custom property. 
+            # Setting custom properties non-animatable is not possible yet, see:
+            # https://projects.blender.org/blender/blender/issues/113506
+            if o.animation_data and o.animation_data.action:
+                fcurves = o.animation_data.action.fcurves
+                for fcurve in fcurves:
+                    if fcurve.data_path == '["selection_order"]':
+                        fcurves.remove(fcurve)
+
             idx += 1
     for o in bpy.context.selected_objects:
         if o not in selection_order:


### PR DESCRIPTION
Fixes #198 

As there is currently no way to make custom properties non-animatable (https://projects.blender.org/blender/blender/issues/113506), check if there is animation data for the custom property of the selected objects and delete it.
Seems hackish, but works.

 | Before | After | 
 |    ---    |   ---   |
| ![before](https://github.com/user-attachments/assets/40809937-26b2-4623-b05f-b350649e6445) | ![after](https://github.com/user-attachments/assets/f04a67d9-87f9-4e17-b4e3-b7d7fbe22ede) |


